### PR TITLE
Setup profile.dev to match profile.release panic behavior.

### DIFF
--- a/panic_immediate_abort/Cargo.toml
+++ b/panic_immediate_abort/Cargo.toml
@@ -6,6 +6,12 @@ edition = "2018"
 
 [dependencies]
 
+[profile.dev]
+# This isn't required for development builds, but makes development
+# build behavior match release builds. To enable unwinding panics
+# during development, simply remove this line.
+panic = 'abort'
+
 [profile.release]
 opt-level = "z"
 lto = true

--- a/xargo/Cargo.toml
+++ b/xargo/Cargo.toml
@@ -6,6 +6,12 @@ edition = "2018"
 
 [dependencies]
 
+[profile.dev]
+# This isn't required for development builds, but makes development
+# build behavior match release builds. To enable unwinding panics
+# during development, simply remove this line.
+panic = 'abort'     # Abort on panic
+
 [profile.release]
 opt-level = 'z'     # Optimize for size.
 lto = true          # Enable Link Time Optimization


### PR DESCRIPTION
It might be useful to have a `[profile.dev]` section which has matching panic behavior for the xargo build (unless the idea was to demonstrate both kinds of panic).