### PR TITLE
Add documentation for using upx

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ Available starting `1.45.0-nightly (2020-05-28)`,
 $ cargo +nightly build -Z strip=symbols
 ```
 
+# Compress the binary
+
+[`uxp`](https://github.com/upx/upx) is a powerful tool for creating a self contained, compressed binary with no addition
+runtime requirements.  It claims to typically reduce file size by 50-70% but the actual result depends on your
+executable.  For our example we see a respectable 23% reduction.
+
+```bash
+$ uxp --best --lzma target/release/min-sized-rust
+```
+
+
 # Optimize For Size
 
 ![Minimum Rust: 1.28](https://img.shields.io/badge/Minimum%20Rust%20Version-1.28-brightgreen.svg)


### PR DESCRIPTION
Adding documentation for using upx to further cut binary size.  Here are the result for using on this project

```
stusmall@thinkpad-t520:~/Workspace/min-sized-rust$ cargo build --release; ls -sh target/release/min-sized-rust
    Finished release [optimized] target(s) in 0.01s
1.3M target/release/min-sized-rust
stusmall@thinkpad-t520:~/Workspace/min-sized-rust$ cargo build --release; upx --best --lzma target/release/min-sized-rust; ls -sh target/release/min-sized-rust
    Finished release [optimized] target(s) in 0.01s
                       Ultimate Packer for eXecutables
                          Copyright (C) 1996 - 2018
UPX 3.95        Markus Oberhumer, Laszlo Molnar & John Reiser   Aug 26th 2018

        File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
   1302856 ->    303456   23.29%   linux/amd64   min-sized-rust                

Packed 1 file.
300K target/release/min-sized-rust
```


I'm getting considerably better compression with larger projects