### PR TITLE
Build no_std project on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,9 @@ jobs:
     name: no_std
     strategy:
       matrix:
+        platform: [ ubuntu-latest, macos-latest ]
         toolchain: [ stable, 1.30.0, nightly ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Add the following platform build targets:

- `no_std`: macOS