### PR TITLE
Add `strip=true` to the repo examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ opt-level = "z"     # Optimize for size.
 lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = "abort"     # Abort on panic
+strip = true        # Automatically strip symbols from the binary.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ host: x86_64-apple-darwin
 $ cargo +nightly build -Z build-std=std,panic_abort --target x86_64-apple-darwin --release
 ```
 
-Remember to `strip` the resulting executable. On macOS, the final binary size is reduced to 51KB.
+On macOS, the final stripped binary size is reduced to 51KB.
 
 # Remove `panic` String Formatting with `panic_immediate_abort`
 
@@ -205,7 +205,7 @@ $ cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_
     --target x86_64-apple-darwin --release
 ```
 
-Remember to `strip` the resulting executable. On macOS, the final binary size is reduced to 30KB.
+On macOS, the final stripped binary size is reduced to 30KB.
 
 # Remove `core::fmt` with `#![no_main]` and Careful Usage of `libstd`
 

--- a/build_std/Cargo.toml
+++ b/build_std/Cargo.toml
@@ -17,3 +17,4 @@ opt-level = "z"     # Optimize for size.
 lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = "abort"     # Abort on panic
+strip = true        # Automatically strip symbols from the binary.

--- a/no_main/Cargo.toml
+++ b/no_main/Cargo.toml
@@ -18,3 +18,4 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 panic = "abort"
+strip = true

--- a/no_std/Cargo.toml
+++ b/no_std/Cargo.toml
@@ -16,3 +16,4 @@ opt-level = "z"     # Optimize for size.
 lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = "abort"     # Abort on panic
+strip = true        # Automatically strip symbols from the binary.


### PR DESCRIPTION
Enables strip in the example `Cargo.toml` files in this repository, per the recommendation now in README after #34.

The reminder to `strip` has been removed from the README, since the examples will now do that automatically.