### PR TITLE
extra info for stripping debug symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ Modify `Cargo.toml` in this way:
 strip = true  # Automatically strip symbols from the binary.
 ```
 
+> [!WARNING]
+> Removing debug symbols will prevent some features like backtraces from being properly displayed
+
+> [!NOTE]
+> In some settings, you want to strip symbols but keep them around for debugging purposes.  You
+> can do this by running the following two commands:
+>
+> ```
+> objcopy --only-keep-debug target/release/min-sized-rust min-sized-rust.dbg
+> objcopy --strip-debug --strip-unneeded --remove-section=".gnu_debuglink" --add-gnu-debuglink=min-sized-rust.dbg target/release/min-sized-rust
+> ```
+
 **Prior to Rust 1.59**, run [`strip`](https://linux.die.net/man/1/strip) directly on
 the `.elf` file instead:
 


### PR DESCRIPTION
I don't know if this is of interest in your repo, but given that a) stripping debug symbols is (one of) the best ways to reduce the size of your binary, and b) often you want to keep debug symbols around for, well, debugging purposes, I thought it would maybe be helpful to include a bit of extra context here.

It took me a while to figure this out, because just naively saving the symbols to a second file doesn't work, as noted [here](https://frehberg.com/2019/05/rust-handling-executables-and-their-debug-symbols/) but I finally found a [post](https://users.rust-lang.org/t/how-to-gdb-with-split-debug-files/102989/2) by @p-kraszewski that showed me the magic incantation to get this to work.

Feel free to reject/close/modify if you think this isn't useful!