### PR TITLE
Improve std feature flag in README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,5 +75,5 @@ jobs:
         working-directory: ${{ matrix.project_dir }}
         run: >
           rustup component add rust-src;
-          RUSTFLAGS="-Zlocation-detail=none" cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features="std/optimize_for_size" --target x86_64-unknown-linux-gnu --release;
+          RUSTFLAGS="-Zlocation-detail=none" cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features="optimize_for_size" --target x86_64-unknown-linux-gnu --release;
           cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release;

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ host: x86_64-apple-darwin
 # Add the =std,panic_abort to the option to make panic = "abort" Cargo.toml option work.
 # See: https://github.com/rust-lang/wg-cargo-std-aware/issues/56
 $ RUSTFLAGS="-Zlocation-detail=none" cargo +nightly build -Z build-std=std,panic_abort \
-  -Z build-std-features="std/optimize_for_size" \
+  -Z build-std-features="optimize_for_size" \
   --target x86_64-apple-darwin --release
 ```
 


### PR DESCRIPTION
Sorry, my previous example was hardcoded for `std`, but in theory this flag could be used also for core/alloc, if some people want to only rebuild these libstd crates. Using just `optimize_for_size` should be more rgeneral.