### PR TITLE
Recommend -Zshare-generics=false with opt-level=z

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ Enable this in `Cargo.toml`:
 panic = "abort"
 ```
 
+# (Un)Share Generics
+
+![Minimum Rust: Nightly](https://img.shields.io/badge/Minimum%20Rust%20Version-nightly-orange.svg)
+
+Currently Rust enables `-Zshare-generics` implicitly for opt-level `"s"` and `"z"`.
+Just like `"s"` vs `"z"`, this can sometimes be helpful and sometimes cause larger binaries.
+
+To avoid sharing generics, use the unstable
+`rustc` `-Zshare-generics` flag:
+flag:
+
+```bash
+$ RUSTFLAGS="-Zshare-generics=false" cargo +nightly build --release
+```
+
+
 # Remove Location Details
 
 ![Minimum Rust: Nightly](https://img.shields.io/badge/Minimum%20Rust%20Version-nightly-orange.svg)


### PR DESCRIPTION
opt-level=z or opt-level=s implicitly enables -Zshare-generics=true, which sometimes has a positive and sometimes has a negative impact.

See https://github.com/rust-lang/rust/issues/142164