### PR TITLE
Add `distroless` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ create minimum sized container images that run Rust binaries.
 - [docker-slim](https://github.com/docker-slim/docker-slim) - Minify Docker images
 - [dive](https://github.com/wagoodman/dive) - A tool for exploring a container image and
   discovering ways to shrink the size of the image.
+- [distroless](https://github.com/GoogleContainerTools/distroless) - 2MB base image to run statically linked Rust program
 
 # References
 


### PR DESCRIPTION
`distroless` provides an excellent base image to run Rust programs. For Rust programs linked with musl, use `distroless/static` which weights ~2MB. For Rust programs linked with glibc, use `distroless/cc` which is ~20MB